### PR TITLE
added api key in example to avoid exception (fixes #12)

### DIFF
--- a/examples/get_roles_with_cass.py
+++ b/examples/get_roles_with_cass.py
@@ -2,6 +2,7 @@ import cassiopeia as cass
 from roleidentification import pull_data
 from roleidentification.utilities import get_team_roles
 
+API_KEY = "your key here"
 
 def main():
     print("Pulling data...")
@@ -10,6 +11,7 @@ def main():
     print()
 
     # Pull a summoner's most recent match using Cassiopeia
+    cass.set_riot_api_key(API_KEY)
     match = cass.get_match(id=3344134840, region="NA")
     team = match.blue_team
     # Get the roles


### PR DESCRIPTION
This PR fixes the `get_roles_with_cass.py` example script. Previously, the script would fail to run and give an exception (as described in issue #12). The script does not give an exception if an API key is given to Cassiopeia.